### PR TITLE
Add separate workflows for Hoodi and Holesky

### DIFF
--- a/.github/workflows/ci-dev-holesky.yml
+++ b/.github/workflows/ci-dev-holesky.yml
@@ -1,10 +1,10 @@
-name: CI Dev Hoodi
+name: CI Dev Holesky
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - develop
+      - holesky
     paths-ignore:
       - ".github/**"
 
@@ -25,5 +25,5 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
           TARGET_REPO: "lidofinance/infra-mainnet"
-          TARGET_WORKFLOW: "deploy_hoodi_testnet_csm_prover_tool.yaml"
-          TARGET: "develop"
+          TARGET_WORKFLOW: "deploy_holesky_testnet_csm_prover_tool.yaml"
+          TARGET: "holesky"


### PR DESCRIPTION
## Summary

Add separate workflows for Hoodi (branch `develop`, image `:dev`) and Holesky (branch `holesky`, image `:dev-holesky`).
Part of [SRE-2467](https://linear.app/lidofi/issue/SRE-2467).

## Changes

- feat: add separate wfs for hoodi and holesky
