### PR TITLE
chore: replace Harbor registry endpoint

### DIFF
--- a/.github/workflows/build-push-harbor.yml
+++ b/.github/workflows/build-push-harbor.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   APP: csm-prover-tool
-  REGISTRY: harbor.dev.k8s-dev.org
+  REGISTRY: registry.dev.k8s-dev.org
   REPOSITORY: team-csm
   REGISTRY_USER: robot$team-csm-rw
   IMAGE_TAG: dev


### PR DESCRIPTION
Replaces harbor.dev.k8s-dev.org with registry.dev.k8s-dev.org. Do not merge till endpoints are actually switched in k8s-cluster!